### PR TITLE
Fix inequity aversion argument order

### DIFF
--- a/socialjax/environments/cleanup/clean_up.py
+++ b/socialjax/environments/cleanup/clean_up.py
@@ -1375,7 +1375,7 @@ class Clean_up(MultiAgentEnv):
                 if self.smooth_rewards:
                     should_smooth = (state.inner_t % 1) == 0
                     new_smooth_rewards = 0.99 * 0.01* state.smooth_rewards + original_rewards
-                    rewards,disadvantageous,advantageous = self.get_inequity_aversion_rewards_immediate(new_smooth_rewards, self.inequity_aversion_target_agents, state.inner_t, self.inequity_aversion_alpha, self.inequity_aversion_beta)
+                    rewards, disadvantageous, advantageous = self.get_inequity_aversion_rewards_immediate(new_smooth_rewards, state.inner_t, self.inequity_aversion_target_agents, self.inequity_aversion_alpha, self.inequity_aversion_beta)
                     state = state.replace(smooth_rewards=new_smooth_rewards)
                     info = {
                     "original_rewards": original_rewards.squeeze(),
@@ -1383,7 +1383,7 @@ class Clean_up(MultiAgentEnv):
                     "shaped_rewards": rewards.squeeze(),
                 }
                 else:
-                    rewards,disadvantageous,advantageous = self.get_inequity_aversion_rewards_immediate(original_rewards, self.inequity_aversion_target_agents, state.inner_t, self.inequity_aversion_alpha, self.inequity_aversion_beta)
+                    rewards, disadvantageous, advantageous = self.get_inequity_aversion_rewards_immediate(original_rewards, state.inner_t, self.inequity_aversion_target_agents, self.inequity_aversion_alpha, self.inequity_aversion_beta)
                     info = {
                     "original_rewards": original_rewards.squeeze(),
                     "shaped_rewards": rewards.squeeze(),

--- a/socialjax/environments/coin_game/coin_game.py
+++ b/socialjax/environments/coin_game/coin_game.py
@@ -935,7 +935,7 @@ class CoinGame(MultiAgentEnv):
                 if self.smooth_rewards:
                     should_smooth = (state.inner_t % 1) == 0
                     new_smooth_rewards = 0.99 * 0.01* state.smooth_rewards + original_rewards
-                    rewards,disadvantageous,advantageous = self.get_inequity_aversion_rewards_immediate(new_smooth_rewards, self.inequity_aversion_target_agents, state.inner_t, self.inequity_aversion_alpha, self.inequity_aversion_beta)
+                    rewards, disadvantageous, advantageous = self.get_inequity_aversion_rewards_immediate(new_smooth_rewards, state.inner_t, self.inequity_aversion_target_agents, self.inequity_aversion_alpha, self.inequity_aversion_beta)
                     state = state.replace(smooth_rewards=new_smooth_rewards)
                     info = {
                     "original_rewards": rewards.squeeze(),
@@ -943,7 +943,7 @@ class CoinGame(MultiAgentEnv):
                     "shaped_rewards": rewards.squeeze(),
                 }
                 else:
-                    rewards,disadvantageous,advantageous = self.get_inequity_aversion_rewards_immediate(original_rewards, self.inequity_aversion_target_agents, state.inner_t, self.inequity_aversion_alpha, self.inequity_aversion_beta)
+                    rewards, disadvantageous, advantageous = self.get_inequity_aversion_rewards_immediate(original_rewards, state.inner_t, self.inequity_aversion_target_agents, self.inequity_aversion_alpha, self.inequity_aversion_beta)
                     info = {
                     "original_rewards": rewards.squeeze(),
                     "shaped_rewards": rewards.squeeze(),

--- a/socialjax/environments/common_harvest/harvest_open.py
+++ b/socialjax/environments/common_harvest/harvest_open.py
@@ -1399,7 +1399,7 @@ class Harvest_open(MultiAgentEnv):
                 if self.smooth_rewards:
                     should_smooth = (state.inner_t % 1) == 0
                     new_smooth_rewards = 0.99 * 0.01* state.smooth_rewards + original_rewards
-                    rewards,disadvantageous,advantageous = self.get_inequity_aversion_rewards_immediate(new_smooth_rewards, self.inequity_aversion_target_agents, state.inner_t, self.inequity_aversion_alpha, self.inequity_aversion_beta)
+                    rewards, disadvantageous, advantageous = self.get_inequity_aversion_rewards_immediate(new_smooth_rewards, state.inner_t, self.inequity_aversion_target_agents, self.inequity_aversion_alpha, self.inequity_aversion_beta)
                     state = state.replace(smooth_rewards=new_smooth_rewards)
                     info = {
                     "original_rewards": original_rewards.squeeze(),
@@ -1407,7 +1407,7 @@ class Harvest_open(MultiAgentEnv):
                     "shaped_rewards": rewards.squeeze(),
                 }
                 else:
-                    rewards,disadvantageous,advantageous = self.get_inequity_aversion_rewards_immediate(original_rewards, self.inequity_aversion_target_agents, state.inner_t, self.inequity_aversion_alpha, self.inequity_aversion_beta)
+                    rewards, disadvantageous, advantageous = self.get_inequity_aversion_rewards_immediate(original_rewards, state.inner_t, self.inequity_aversion_target_agents, self.inequity_aversion_alpha, self.inequity_aversion_beta)
                     info = {
                     "original_rewards": original_rewards.squeeze(),
                     "shaped_rewards": rewards.squeeze(),

--- a/socialjax/environments/coop_mining/coop_mining.py
+++ b/socialjax/environments/coop_mining/coop_mining.py
@@ -675,7 +675,7 @@ class CoopMining(MultiAgentEnv):
             if self.smooth_rewards:
                 should_smooth = (state.inner_t % 1) == 0
                 new_smooth_rewards = 0.99 * 0.99 * state.smooth_rewards + final_rewards
-                rewards,disadvantageous,advantageous = self.get_inequity_aversion_rewards_immediate(new_smooth_rewards, self.inequity_aversion_target_agents, state.inner_t, self.inequity_aversion_alpha, self.inequity_aversion_beta)
+                rewards, disadvantageous, advantageous = self.get_inequity_aversion_rewards_immediate(new_smooth_rewards, state.inner_t, self.inequity_aversion_target_agents, self.inequity_aversion_alpha, self.inequity_aversion_beta)
                 state = state.replace(smooth_rewards=new_smooth_rewards)
                 info = {
                 "original_rewards": final_rewards.squeeze(),
@@ -683,7 +683,7 @@ class CoopMining(MultiAgentEnv):
                 "shaped_rewards": rewards.squeeze(),
             }
             else:
-                rewards,disadvantageous,advantageous = self.get_inequity_aversion_rewards_immediate(final_rewards, self.inequity_aversion_target_agents, state.inner_t, self.inequity_aversion_alpha, self.inequity_aversion_beta)
+                rewards, disadvantageous, advantageous = self.get_inequity_aversion_rewards_immediate(final_rewards, state.inner_t, self.inequity_aversion_target_agents, self.inequity_aversion_alpha, self.inequity_aversion_beta)
                 info = {
                 "original_rewards": final_rewards.squeeze(),
                 "shaped_rewards": rewards.squeeze(),

--- a/socialjax/environments/gift/gift.py
+++ b/socialjax/environments/gift/gift.py
@@ -1137,7 +1137,7 @@ class Gift(MultiAgentEnv):
                 if self.smooth_rewards:
                     should_smooth = (state.inner_t % 1) == 0
                     new_smooth_rewards = 0.99 * 0.99* state.smooth_rewards + original_rewards
-                    rewards,disadvantageous,advantageous = self.get_inequity_aversion_rewards_immediate(new_smooth_rewards, self.inequity_aversion_target_agents, state.inner_t, self.inequity_aversion_alpha, self.inequity_aversion_beta)
+                    rewards, disadvantageous, advantageous = self.get_inequity_aversion_rewards_immediate(new_smooth_rewards, state.inner_t, self.inequity_aversion_target_agents, self.inequity_aversion_alpha, self.inequity_aversion_beta)
                     state = state.replace(smooth_rewards=new_smooth_rewards)
                     info = {
                     "original_rewards": original_rewards.squeeze(),
@@ -1145,7 +1145,7 @@ class Gift(MultiAgentEnv):
                     "shaped_rewards": rewards.squeeze(),
                 }
                 else:
-                    rewards,disadvantageous,advantageous = self.get_inequity_aversion_rewards_immediate(original_rewards, self.inequity_aversion_target_agents, state.inner_t, self.inequity_aversion_alpha, self.inequity_aversion_beta)
+                    rewards, disadvantageous, advantageous = self.get_inequity_aversion_rewards_immediate(original_rewards, state.inner_t, self.inequity_aversion_target_agents, self.inequity_aversion_alpha, self.inequity_aversion_beta)
                     info = {
                     "original_rewards": original_rewards.squeeze(),
                     "shaped_rewards": rewards.squeeze(),

--- a/socialjax/environments/mushrooms/mushrooms.py
+++ b/socialjax/environments/mushrooms/mushrooms.py
@@ -1313,7 +1313,7 @@ class Mushrooms(MultiAgentEnv):
                 if self.smooth_rewards:
                     should_smooth = (state.inner_t % 1) == 0
                     new_smooth_rewards = 0.99 * 0.01* state.smooth_rewards + original_rewards
-                    rewards,disadvantageous,advantageous = self.get_inequity_aversion_rewards_immediate(new_smooth_rewards, self.inequity_aversion_target_agents, state.inner_t, self.inequity_aversion_alpha, self.inequity_aversion_beta)
+                    rewards, disadvantageous, advantageous = self.get_inequity_aversion_rewards_immediate(new_smooth_rewards, state.inner_t, self.inequity_aversion_target_agents, self.inequity_aversion_alpha, self.inequity_aversion_beta)
                     state = state.replace(smooth_rewards=new_smooth_rewards)
                     info = {
                     "original_rewards": original_rewards.squeeze(),
@@ -1321,7 +1321,7 @@ class Mushrooms(MultiAgentEnv):
                     "shaped_rewards": rewards.squeeze(),
                 }
                 else:
-                    rewards,disadvantageous,advantageous = self.get_inequity_aversion_rewards_immediate(original_rewards, self.inequity_aversion_target_agents, state.inner_t, self.inequity_aversion_alpha, self.inequity_aversion_beta)
+                    rewards, disadvantageous, advantageous = self.get_inequity_aversion_rewards_immediate(original_rewards, state.inner_t, self.inequity_aversion_target_agents, self.inequity_aversion_alpha, self.inequity_aversion_beta)
                     info = {
                     "original_rewards": original_rewards.squeeze(),
                     "shaped_rewards": rewards.squeeze(),

--- a/socialjax/environments/territory/territory_env.py
+++ b/socialjax/environments/territory/territory_env.py
@@ -2027,7 +2027,7 @@ class Territory_open(MultiAgentEnv):
                 if self.smooth_rewards:
                     should_smooth = (state.inner_t % 1) == 0
                     new_smooth_rewards = 0.99 * 0.01* state.smooth_rewards + original_rewards
-                    rewards,disadvantageous,advantageous = self.get_inequity_aversion_rewards_immediate(new_smooth_rewards, self.inequity_aversion_target_agents, state.inner_t, self.inequity_aversion_alpha, self.inequity_aversion_beta)
+                    rewards, disadvantageous, advantageous = self.get_inequity_aversion_rewards_immediate(new_smooth_rewards, state.inner_t, self.inequity_aversion_target_agents, self.inequity_aversion_alpha, self.inequity_aversion_beta)
                     state = state.replace(smooth_rewards=new_smooth_rewards)
                     info = {
                     "original_rewards": original_rewards.squeeze(),
@@ -2035,7 +2035,7 @@ class Territory_open(MultiAgentEnv):
                     "shaped_rewards": rewards.squeeze(),
                 }
                 else:
-                    rewards,disadvantageous,advantageous = self.get_inequity_aversion_rewards_immediate(original_rewards, self.inequity_aversion_target_agents, state.inner_t, self.inequity_aversion_alpha, self.inequity_aversion_beta)
+                    rewards, disadvantageous, advantageous = self.get_inequity_aversion_rewards_immediate(original_rewards, state.inner_t, self.inequity_aversion_target_agents, self.inequity_aversion_alpha, self.inequity_aversion_beta)
                     info = {
                     "original_rewards": original_rewards.squeeze(),
                     "shaped_rewards": rewards.squeeze(),


### PR DESCRIPTION
Inequity aversion reward argument signature is:

`get_inequity_aversion_rewards_immediate(self, array, inner_t, target_agents=None, alpha=5, beta=0.05):`

However, previous calls passed `target_agents` before `inner_t`:

`self.get_inequity_aversion_rewards_immediate(new_smooth_rewards, self.inequity_aversion_target_agents, state.inner_t, self.inequity_aversion_alpha, self.inequity_aversion_beta)`

This results in `state.inner_t` being interpreted as `target_agents`. This PR swaps the argument order of these two arguments for all environments.