### PR TITLE
Fixed stale ore_miners registry allowing solo gold finalization

### DIFF
--- a/socialjax/environments/coop_mining/coop_mining.py
+++ b/socialjax/environments/coop_mining/coop_mining.py
@@ -863,6 +863,14 @@ class CoopMining(MultiAgentEnv):
             revert = (distinct_count > self.min_gold_miners) & mining_gold
             partial = (distinct_count > 0) & (distinct_count < self.min_gold_miners) & mining_gold
 
+            # Clear the miner registry once a cell resolves (finalize or revert), so a
+            # future regrowth doesn't inherit stale miner IDs from this round.
+            new_miners = jnp.where(
+                finalize | revert,
+                -1 * jnp.ones_like(new_miners),
+                new_miners
+            )
+
             # Update item
             gold_item = jnp.where(partial, Items.gold_partial, new_item_if_iron)
             gold_item = jnp.where(finalize, Items.ore_wait, gold_item)
@@ -924,6 +932,17 @@ class CoopMining(MultiAgentEnv):
 
         # Decrement partial gold timer
         final_partial_cd = jnp.maximum(final_partial_cd - 1, 0)
+
+        # Expire the coordination window: a cell sitting in gold_partial whose
+        # countdown has run out reverts to a fresh gold_ore and its miner
+        # registry is cleared, so late/solo miners can't finalize off stale IDs.
+        expired = (final_grid == Items.gold_partial) & (final_partial_cd == 0)
+        final_grid = jnp.where(expired, Items.gold_ore, final_grid)
+        final_ore_miners = jnp.where(
+            expired[..., None],
+            -1 * jnp.ones_like(final_ore_miners),
+            final_ore_miners
+        )
 
         return (final_positions,
                 final_iron_rewards,


### PR DESCRIPTION
Fixes a coordination bug in `coop_mining`. The per-cell miner registry (`ore_miners`) was never cleared after a gold cell finalized, so once a cell had been jointly mined once, a single agent could re-finalize the same cell alone after regrowth. The stale distinct-miner count already met `min_gold_miners`. Separately, `partial_ore_countdown/gold_mining_window` was decremented every step but never read anywhere, so the coordination window had no effect.